### PR TITLE
Fix escaping issue

### DIFF
--- a/attributes/pure_multiple_files/form.php
+++ b/attributes/pure_multiple_files/form.php
@@ -45,7 +45,7 @@ $akMaxFilesCount = $akMaxFilesCount ? $akMaxFilesCount : 0
         if (is_array($currentFiles)) {
             foreach ($currentFiles as $index => $file) {
                 $fv = $file->getRecentVersion();
-                echo '{fID:'.$fv->getFileID().',filename:\''.$fv->getTitle().'\',thumbnailIMG:\''.$fv->getListingThumbnailImage().'\'}';
+                echo '{fID:'.$fv->getFileID().',filename:'.json_encode($fv->getTitle()).',thumbnailIMG:'.json_encode($fv->getListingThumbnailImage()).'}';
                 if ($index < count($currentFiles) - 1) {
                     echo ',';
                 }


### PR DESCRIPTION
If in your `pageTheme.php` the `getThemeResponsiveImageMap` function is in use then the generated style from `getListingThumbnailImage()` breaks the javascript code. See: 
https://github.com/concrete5/concrete5/blob/35c800305212cb619cd27cb77ba48b7ea20c8f8c/concrete/src/Html/Object/Picture.php#L89

So i think is better to json_encode the return of `getListingThumbnailImage `function.